### PR TITLE
Change search ID from int to canonical UUID String

### DIFF
--- a/src/edu/cmu/cs/diamond/opendiamond/Connection.java
+++ b/src/edu/cmu/cs/diamond/opendiamond/Connection.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 class Connection {
 
@@ -165,30 +166,19 @@ class Connection {
 
     public void sendStart(Set<String> pushAttributes) throws IOException {
         try {
-            // Generate a search ID that should be unique over the lifetime
-            // of this scope cookie.  OpenDiamond-Java doesn't use this for
-            // anything, but the servers may choose to use it (in concert
-            // with the scope cookie) to correlate a particular search across
-            // multiple servers.  The protocol only gives us 32 bits, so
-            // divide them as follows:
-            // - 24 bits: millisecond-granularity timestamp right-shifted
-            //   by 11 bits.  This gives us a 397-day rollover and a 2-second
-            //   resolution.  Most scope cookies expire much sooner than
-            //   397 days.
-            // - 8 bits: random uniquifier.  This can't be a serial number
-            //   because there may be multiple uncoordinated clients.
-            //   This allows on average 16 new searches per 2-second tick
-            //   before we hit a collision due to the birthday paradox.
-            int searchId = (int) (((System.currentTimeMillis() >>> 11)
-                    & 0xffffff) << 8);
-            byte rand[] = new byte[1];
-            new SecureRandom().nextBytes(rand);
-            searchId |= ((int) rand[0]) & 0xff;
+            //Generate a random UUID and use it as the search ID. The search
+        	// ID is unique over the lifetime of this scope cookie.
+        	// OpenDiamond-Java doesn't use this for anything, but the servers
+        	// may choose to use it (in concert with the scope cookie) to
+        	// correlate a particular search across multiple servers.
+        	UUID uuid = UUID.randomUUID();
+        	String searchId_utf16 = uuid.toString();
+        	byte[] searchId = searchId_utf16.getBytes("UTF-8");            
             byte[] encodedStart = new XDR_start(searchId,
                     pushAttributes).encode();
 
-            // start = 27
-            new RPC(this, hostname, 27, encodedStart).doRPC().checkStatus();
+            // start = 28
+            new RPC(this, hostname, 28, encodedStart).doRPC().checkStatus();
         } catch (IOException e) {
             close();
             throw e;

--- a/src/edu/cmu/cs/diamond/opendiamond/XDR_object.java
+++ b/src/edu/cmu/cs/diamond/opendiamond/XDR_object.java
@@ -19,14 +19,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 class XDR_object {
-    private final long searchID;
-
     private final byte[] data;
 
     private final Map<String, byte[]> attributes;
 
     public XDR_object(XDRGetter buf) throws IOException {
-        searchID = buf.getInt() & 0xFFFFFFFFL;
         data = buf.getOpaque();
 
         Map<String, byte[]> tmpMap = new HashMap<String, byte[]>();
@@ -39,10 +36,6 @@ class XDR_object {
         attributes = Collections.unmodifiableMap(tmpMap);
     }
 
-    public long getSearchID() {
-        return searchID;
-    }
-
     public byte[] getData() {
         return data;
     }
@@ -53,7 +46,7 @@ class XDR_object {
 
     @Override
     public String toString() {
-        return "searchID: " + searchID + ", attributes: " + attributes
+        return "attributes: " + attributes
                 + ", data: " + Arrays.toString(data);
     }
 }

--- a/src/edu/cmu/cs/diamond/opendiamond/XDR_start.java
+++ b/src/edu/cmu/cs/diamond/opendiamond/XDR_start.java
@@ -18,11 +18,11 @@ import java.io.IOException;
 import java.util.Set;
 
 class XDR_start implements XDREncodeable {
-    private final int searchID;
+    private final byte[] searchID;
 
     private final XDR_attr_name_list attributes;
 
-    public XDR_start(int searchID, Set<String> attributes) {
+    public XDR_start(byte[] searchID, Set<String> attributes) {
         this.searchID = searchID;
         if (attributes != null) {
             this.attributes = new XDR_attr_name_list(attributes);
@@ -36,7 +36,7 @@ class XDR_start implements XDREncodeable {
         DataOutputStream out = new DataOutputStream(baos);
 
         try {
-            out.writeInt(searchID);
+            out.write(searchID, 0, 36);
             if (attributes != null) {
                 out.writeInt(1);
                 out.write(attributes.encode());


### PR DESCRIPTION
The current search ID uses int, and for randomness and because of XDR
alignment requirements, a lot of transformation needs to be done. This
could be done in a cleaner way using UUID.

Remove search Id field in object for two reasons:
- Object uses long search Id, and does not encode string UUID
- Search ID field will be removed from objects in the future

Change start RPC number (from 27 to 28).
