### PR TITLE
Remove search ID andat data from object

### DIFF
--- a/src/edu/cmu/cs/diamond/opendiamond/BlastGetter.java
+++ b/src/edu/cmu/cs/diamond/opendiamond/BlastGetter.java
@@ -33,7 +33,7 @@ class BlastGetter implements Callable<Object> {
         this.maxOutstandingRequests = maxOutstandingRequests;
     }
 
-    private final int CMD = 1;
+    private final int CMD = 2;
 
     private final byte[] DATA = new byte[0];
 
@@ -63,7 +63,7 @@ class BlastGetter implements Callable<Object> {
             XDR_object obj = getAndAcknowldgeBlastChannelObject();
 
             // no more objects?
-            if (obj.getAttributes().isEmpty() && (obj.getData().length == 0)) {
+            if (obj.getAttributes().isEmpty()) {
                 return null;
             }
 

--- a/src/edu/cmu/cs/diamond/opendiamond/Search.java
+++ b/src/edu/cmu/cs/diamond/opendiamond/Search.java
@@ -165,16 +165,7 @@ public class Search {
         // compose new Result
         XDR_object obj = bco.getObj();
         Map<String, byte[]> attrs = obj.getAttributes();
-        byte[] data = obj.getData();
-
-        // when push attributes are not set, data is in data, not "" in
-        // attributes
-        if (data.length != 0) {
-            HashMap<String, byte[]> newMap = new HashMap<String, byte[]>(attrs);
-            newMap.put("", data);
-            attrs = Collections.unmodifiableMap(newMap);
-        }
-
+        
         Result result = new Result(attrs, bco.getHostname());
 
         logging.saveGetNewResult(result);

--- a/src/edu/cmu/cs/diamond/opendiamond/XDR_object.java
+++ b/src/edu/cmu/cs/diamond/opendiamond/XDR_object.java
@@ -19,16 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 class XDR_object {
-    private final long searchID;
-
-    private final byte[] data;
-
     private final Map<String, byte[]> attributes;
 
     public XDR_object(XDRGetter buf) throws IOException {
-        searchID = buf.getInt() & 0xFFFFFFFFL;
-        data = buf.getOpaque();
-
         Map<String, byte[]> tmpMap = new HashMap<String, byte[]>();
         int attrCount = buf.getInt();
         for (int i = 0; i < attrCount; i++) {
@@ -39,21 +32,12 @@ class XDR_object {
         attributes = Collections.unmodifiableMap(tmpMap);
     }
 
-    public long getSearchID() {
-        return searchID;
-    }
-
-    public byte[] getData() {
-        return data;
-    }
-
     public Map<String, byte[]> getAttributes() {
         return attributes;
     }
 
     @Override
     public String toString() {
-        return "searchID: " + searchID + ", attributes: " + attributes
-                + ", data: " + Arrays.toString(data);
+        return "attributes: " + attributes;
     }
 }


### PR DESCRIPTION
In the past, search ID was used for relating objects to searches because
searches for different channels were done on different channels. Now all
searches are done on the same channel, and it is unnecessary to relate
objects to searches. Therefore, remove search ID from objects.

Also, remove data field from object since it is not used anymore.
Object data is now stored in the attributes list with the zero-length
string key.

Change get_object RPC to 2 (from 1).
